### PR TITLE
Mpl 1.0 compatibility

### DIFF
--- a/examples/plugins/contrastsetter_demo.py
+++ b/examples/plugins/contrastsetter_demo.py
@@ -1,10 +1,8 @@
-import skimage
 from skimage import data
 from skloupe.viewers import ImageViewer
 from skloupe.plugins import ContrastSetter
 
-
-image = data.coins()#skimage.img_as_float(data.coins())
+image = data.coins()
 view = ImageViewer(image)
 cs = ContrastSetter(view)
 view.show()

--- a/examples/plugins/contrastsetter_demo.py
+++ b/examples/plugins/contrastsetter_demo.py
@@ -1,0 +1,10 @@
+import skimage
+from skimage import data
+from skloupe.viewers import ImageViewer
+from skloupe.plugins import ContrastSetter
+
+
+image = data.coins()#skimage.img_as_float(data.coins())
+view = ImageViewer(image)
+cs = ContrastSetter(view)
+view.show()

--- a/examples/plugins/edgedetector_demo.py
+++ b/examples/plugins/edgedetector_demo.py
@@ -3,7 +3,6 @@ from skimage import data
 from skloupe.viewers import ImageViewer
 from skloupe.plugins import EdgeDetector
 
-
 image = skimage.img_as_float(data.camera())
 view = ImageViewer(image)
 ed = EdgeDetector(view)

--- a/examples/plugins/edgedetector_demo.py
+++ b/examples/plugins/edgedetector_demo.py
@@ -3,6 +3,7 @@ from skimage import data
 from skloupe.viewers import ImageViewer
 from skloupe.plugins import EdgeDetector
 
+
 image = skimage.img_as_float(data.camera())
 view = ImageViewer(image)
 ed = EdgeDetector(view)

--- a/skloupe/plugins/__init__.py
+++ b/skloupe/plugins/__init__.py
@@ -1,3 +1,3 @@
 from lineprofile import LineProfile
 from edgedetector import EdgeDetector
-
+from contrastsetter import ContrastSetter

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -1,0 +1,131 @@
+import matplotlib.pyplot as plt
+from skimage.filter import canny
+from skimage.util.dtype import dtype_range
+from skimage.exposure import histogram
+
+import numpy as np
+
+from .base import Plugin
+from ..widgets.slider import Slider
+
+
+__all__ = ['ContrastSetter']
+
+
+class ContrastSetter(Plugin):
+    """Plugin to manualy adjust the contrast of an image.
+    Ony linear adjustment are possible. Source image is not modified.
+
+    Parameters
+    ----------
+    image_window : ImageViewer instance.
+        Window containing image used in measurement.
+    
+    """
+
+    def __init__(self, image_window):
+
+        figure, axes = plt.subplots(nrows=3, figsize=(6, 1))
+        ax_histo, ax_low, ax_high = axes
+        self.ax_histo = ax_histo
+        Plugin.__init__(self, image_window, figure=figure)
+        
+        hmin, hmax = dtype_range[self.image.dtype.type]
+        if hmax > 255:
+            bins = int(hmax - hmin)
+        else:
+            bins = 256
+        print bins
+        
+        self.hist, self.bin_centers = histogram(self.image.data, bins)
+        low_value, high_value = self.bin_centers[[0, -1]]
+        clip = low_value, high_value
+
+        self.slider_high = Slider(ax_high, clip, label='Maximum',
+                                  value=high_value, on_release=self.update_image)
+        self.slider_low = Slider(ax_low, clip, label='Minimum',
+                                  value=low_value, on_release=self.update_image)
+
+        self.connect_event('key_press_event', self.on_key_press)
+        self.connect_event('scroll_event', self.on_scroll)
+
+        self.original_image = self.imgview.image.copy()
+        self.update_image()
+        self.redraw()
+        
+        print self.help
+
+    @property
+    def help(self):
+        helpstr = ("ContrastSetter plugin\n"
+                   "---------------------\n"
+                   "+ and - keys or mouse scroll\n"
+                   "also change the contrast\n")
+        return helpstr
+        
+    @property
+    def low(self):
+        return self.slider_low.value
+    
+    @property
+    def high(self):
+        return self.slider_high.value
+
+    def update_image(self, event = None):
+        self.draw_colorbar()
+        self.draw_histogram()
+        self.imgview.image = self.original_image.clip(self.low, self.high)
+        self.imgview.redraw()
+        self.redraw()
+
+
+    def draw_histogram(self):
+        hist_lines = self.ax_histo.step(self.bin_centers, self.hist, 
+                                        color = 'k', alpha = 0.5)
+    def draw_colorbar(self):
+        self.colorbar = np.linspace(self.low, self.high,
+                                    256).reshape((1,256))
+        extent = (self.low, self.high,
+                  self.ax_histo.axis()[2], self.ax_histo.axis()[3])
+        self.ax_histo.imshow(self.colorbar, aspect = 'auto',
+                             extent = extent)
+
+    def reset(self):
+        self.slider_high.value = self.bin_centers
+        low_value, high_value = self.bin_centers[[0, -1]]
+        self.update_image()
+
+    def _expand_bonds(self, event):
+        if not event.inaxes: return
+        center = (self.high + self.low) / 2.
+        span = self.high - self.low
+        low = min(self.slider_low.value - span / 20.,
+                  self.slider.valmin)
+        high = max(self.slider_high.value + span / 20.,
+                   self.slider_high.valmax)
+        
+
+    def _restrict_bonds(self, event):
+        if not event.inaxes: return
+        center = (self.high + self.low) / 2.
+        span = self.high - self.low
+        low = min(self.slider_low.value + span / 20.,
+                  self.slider._high.value - span / 20.)
+        high = max(self.slider_high.value - span / 20.,
+                   self.slider_low.value + span / 20.)
+        
+    def on_scroll(self, event):
+        if not event.inaxes: return
+        if event.button == 'up':
+            self._expand_bonds()
+        elif event.button == 'down':
+            self._restrict_bonds()
+
+    def on_key_press(self, event):
+        if not event.inaxes: return
+        elif event.key == '+':
+            self._expand_bonds()
+        elif event.key == '-':
+            self._restrict_bonds()
+        elif event.key == 'r':
+            self.reset()

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -6,6 +6,7 @@ from numpy import linspace, zeros, ones
 from .base import Plugin
 from ..widgets.slider import Slider
 
+
 __all__ = ['ContrastSetter']
 
 

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -1,13 +1,10 @@
 import matplotlib.pyplot as plt
-from skimage.filter import canny
 from skimage.util.dtype import dtype_range
 from skimage.exposure import histogram
-
-import numpy as np
+from numpy import linspace
 
 from .base import Plugin
 from ..widgets.slider import Slider
-
 
 __all__ = ['ContrastSetter']
 
@@ -20,39 +17,39 @@ class ContrastSetter(Plugin):
     ----------
     image_window : ImageViewer instance.
         Window containing image used in measurement.
-    
+
     """
 
     def __init__(self, image_window):
-
         figure, axes = plt.subplots(nrows=3, figsize=(6.5, 3))
-        
         ax_histo, ax_low, ax_high = axes
-        
         self.ax_histo = ax_histo
+
         Plugin.__init__(self, image_window, figure=figure)
+
         hmin, hmax = dtype_range[self.image.dtype.type]
         if hmax > 255:
             bins = int(hmax - hmin)
         else:
             bins = 256
-        print bins
-        
         self.hist, self.bin_centers = histogram(self.image.data, bins)
         low_value, high_value = self.bin_centers[[0, -1]]
         clip = low_value, high_value
 
-        hist_lines = ax_histo.step(self.bin_centers, self.hist, 
-                                   color = 'k', alpha = 1.)
+        hist_lines = ax_histo.step(self.bin_centers, self.hist,
+                                   color = 'r', lw = 2, alpha = 1.)
         self.ax_histo.set_xlim(low_value, high_value)
         self.ax_histo.set_xticks([])
         self.ax_histo.set_yticks([])
 
-
         self.slider_high = Slider(ax_high, clip, label='Maximum',
-                                  value=high_value, on_release=self.update_image)
+                                  value=high_value,
+                                  on_release=self.update_image)
         self.slider_low = Slider(ax_low, clip, label='Minimum',
-                                  value=low_value, on_release=self.update_image)
+                                 value=low_value,
+                                 on_release=self.update_image)
+        self.slider_low.slidermax = self.slider_high
+        self.slider_high.slidermin = self.slider_low
 
         self.connect_event('key_press_event', self.on_key_press)
         self.connect_event('scroll_event', self.on_scroll)
@@ -77,22 +74,20 @@ class ContrastSetter(Plugin):
         return self.slider_high.value
 
     def update_image(self, event = None):
-
         self.draw_colorbar()
         self.imgview.image = self.original_image.clip(self.low, self.high)
         self.imgview.redraw()
         self.redraw()
         
     def draw_colorbar(self):
-        self.colorbar = np.linspace(self.low, self.high,
-                                    256).reshape((1,256))
+        self.colorbar = linspace(self.low, self.high,
+                                 256).reshape((1,256))
         extent = (self.low, self.high,
                   self.ax_histo.axis()[2], self.ax_histo.axis()[3])
         if len(self.ax_histo.images) > 0 :
             del self.ax_histo.images[-1]
         self.ax_histo.imshow(self.colorbar, aspect = 'auto',
                              extent = extent)
-        
 
     def reset(self):
         self.slider_high.value = self.bin_centers
@@ -110,7 +105,6 @@ class ContrastSetter(Plugin):
         self.slider_low.value = low
         self.slider_high.value = high
         self.update_image()
-                
 
     def _restrict_bonds(self, event):
         if not event.inaxes: return
@@ -123,7 +117,6 @@ class ContrastSetter(Plugin):
         self.slider_low.value = low
         self.slider_high.value = high
         self.update_image()
-            
         
     def on_scroll(self, event):
         if not event.inaxes: return
@@ -131,8 +124,6 @@ class ContrastSetter(Plugin):
             self._expand_bonds(event)
         elif event.button == 'down':
             self._restrict_bonds(event)
-
-            
 
     def on_key_press(self, event):
         if not event.inaxes: return

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -11,7 +11,7 @@ __all__ = ['ContrastSetter']
 
 class ContrastSetter(Plugin):
     """Plugin to manualy adjust the contrast of an image.
-    Ony linear adjustment are possible. Source image is not modified.
+    Ony linear adjustments are possible. Source image is not modified.
 
     Parameters
     ----------
@@ -42,10 +42,10 @@ class ContrastSetter(Plugin):
         self.ax_histo.set_xticks([])
         self.ax_histo.set_yticks([])
 
-        self.slider_high = Slider(ax_high, clip, label='Maximum',
+        self.slider_high = Slider(ax_high, clip, label='Max',
                                   value=high_value,
                                   on_release=self.update_image)
-        self.slider_low = Slider(ax_low, clip, label='Minimum',
+        self.slider_low = Slider(ax_low, clip, label='Min',
                                  value=low_value,
                                  on_release=self.update_image)
         self.slider_low.slidermax = self.slider_high
@@ -75,7 +75,7 @@ class ContrastSetter(Plugin):
 
     def update_image(self, event = None):
         self.draw_colorbar()
-        self.imgview.image = self.original_image.clip(self.low, self.high)
+        self.imgview.climits = (self.low, self.high)
         self.imgview.redraw()
         self.redraw()
         
@@ -90,17 +90,17 @@ class ContrastSetter(Plugin):
                              extent = extent)
 
     def reset(self):
-        self.slider_high.value = self.bin_centers
-        low_value, high_value = self.bin_centers[[0, -1]]
+        low, high = self.bin_centers[[0, -1]]
+        self.slider_low.value = low
+        self.slider_high.value = high
         self.update_image()
 
     def _expand_bonds(self, event):
         if not event.inaxes: return
-        center = (self.high + self.low) / 2.
         span = self.high - self.low
-        low = min(self.slider_low.value - span / 20.,
+        low = max(self.slider_low.value - span / 20.,
                   self.slider_low.valmin)
-        high = max(self.slider_high.value + span / 20.,
+        high = min(self.slider_high.value + span / 20.,
                    self.slider_high.valmax)
         self.slider_low.value = low
         self.slider_high.value = high
@@ -108,12 +108,9 @@ class ContrastSetter(Plugin):
 
     def _restrict_bonds(self, event):
         if not event.inaxes: return
-        center = (self.high + self.low) / 2.
         span = self.high - self.low
-        low = min(self.slider_low.value + span / 20.,
-                  self.slider_high.value - span / 20.)
-        high = max(self.slider_high.value - span / 20.,
-                   self.slider_low.value + span / 20.)
+        low = self.slider_low.value + span / 20.
+        high = self.slider_high.value - span / 20.
         self.slider_low.value = low
         self.slider_high.value = high
         self.update_image()

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -25,11 +25,12 @@ class ContrastSetter(Plugin):
 
     def __init__(self, image_window):
 
-        figure, axes = plt.subplots(nrows=3, figsize=(6, 1))
+        figure, axes = plt.subplots(nrows=3, figsize=(6.5, 3))
+        
         ax_histo, ax_low, ax_high = axes
+        
         self.ax_histo = ax_histo
         Plugin.__init__(self, image_window, figure=figure)
-        
         hmin, hmax = dtype_range[self.image.dtype.type]
         if hmax > 255:
             bins = int(hmax - hmin)
@@ -41,6 +42,13 @@ class ContrastSetter(Plugin):
         low_value, high_value = self.bin_centers[[0, -1]]
         clip = low_value, high_value
 
+        hist_lines = ax_histo.step(self.bin_centers, self.hist, 
+                                   color = 'k', alpha = 1.)
+        self.ax_histo.set_xlim(low_value, high_value)
+        self.ax_histo.set_xticks([])
+        self.ax_histo.set_yticks([])
+
+
         self.slider_high = Slider(ax_high, clip, label='Maximum',
                                   value=high_value, on_release=self.update_image)
         self.slider_low = Slider(ax_low, clip, label='Minimum',
@@ -48,11 +56,8 @@ class ContrastSetter(Plugin):
 
         self.connect_event('key_press_event', self.on_key_press)
         self.connect_event('scroll_event', self.on_scroll)
-
         self.original_image = self.imgview.image.copy()
         self.update_image()
-        self.redraw()
-        
         print self.help
 
     @property
@@ -72,23 +77,22 @@ class ContrastSetter(Plugin):
         return self.slider_high.value
 
     def update_image(self, event = None):
+
         self.draw_colorbar()
-        self.draw_histogram()
         self.imgview.image = self.original_image.clip(self.low, self.high)
         self.imgview.redraw()
         self.redraw()
-
-
-    def draw_histogram(self):
-        hist_lines = self.ax_histo.step(self.bin_centers, self.hist, 
-                                        color = 'k', alpha = 0.5)
+        
     def draw_colorbar(self):
         self.colorbar = np.linspace(self.low, self.high,
                                     256).reshape((1,256))
         extent = (self.low, self.high,
                   self.ax_histo.axis()[2], self.ax_histo.axis()[3])
+        if len(self.ax_histo.images) > 0 :
+            del self.ax_histo.images[-1]
         self.ax_histo.imshow(self.colorbar, aspect = 'auto',
                              extent = extent)
+        
 
     def reset(self):
         self.slider_high.value = self.bin_centers
@@ -100,32 +104,41 @@ class ContrastSetter(Plugin):
         center = (self.high + self.low) / 2.
         span = self.high - self.low
         low = min(self.slider_low.value - span / 20.,
-                  self.slider.valmin)
+                  self.slider_low.valmin)
         high = max(self.slider_high.value + span / 20.,
                    self.slider_high.valmax)
-        
+        self.slider_low.value = low
+        self.slider_high.value = high
+        self.update_image()
+                
 
     def _restrict_bonds(self, event):
         if not event.inaxes: return
         center = (self.high + self.low) / 2.
         span = self.high - self.low
         low = min(self.slider_low.value + span / 20.,
-                  self.slider._high.value - span / 20.)
+                  self.slider_high.value - span / 20.)
         high = max(self.slider_high.value - span / 20.,
                    self.slider_low.value + span / 20.)
+        self.slider_low.value = low
+        self.slider_high.value = high
+        self.update_image()
+            
         
     def on_scroll(self, event):
         if not event.inaxes: return
         if event.button == 'up':
-            self._expand_bonds()
+            self._expand_bonds(event)
         elif event.button == 'down':
-            self._restrict_bonds()
+            self._restrict_bonds(event)
+
+            
 
     def on_key_press(self, event):
         if not event.inaxes: return
         elif event.key == '+':
-            self._expand_bonds()
+            self._expand_bonds(event)
         elif event.key == '-':
-            self._restrict_bonds()
+            self._restrict_bonds(event)
         elif event.key == 'r':
             self.reset()

--- a/skloupe/plugins/contrastsetter.py
+++ b/skloupe/plugins/contrastsetter.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 from skimage.util.dtype import dtype_range
 from skimage.exposure import histogram
-from numpy import linspace
+from numpy import linspace, zeros, ones
 
 from .base import Plugin
 from ..widgets.slider import Slider
@@ -80,15 +80,33 @@ class ContrastSetter(Plugin):
         self.redraw()
         
     def draw_colorbar(self):
-        self.colorbar = linspace(self.low, self.high,
-                                 256).reshape((1,256))
-        extent = (self.low, self.high,
-                  self.ax_histo.axis()[2], self.ax_histo.axis()[3])
-        if len(self.ax_histo.images) > 0 :
-            del self.ax_histo.images[-1]
-        self.ax_histo.imshow(self.colorbar, aspect = 'auto',
-                             extent = extent)
-
+        colorbar = linspace(self.low, self.high,
+                            256).reshape((1,256))
+        cbar_extent = (self.low,
+                       self.high,
+                       self.ax_histo.axis()[2],
+                       self.ax_histo.axis()[3])
+        black_rectangle = zeros((1,2))
+        black_extent = (self.ax_histo.axis()[0],
+                        self.low,
+                        self.ax_histo.axis()[2],
+                        self.ax_histo.axis()[3])
+        white_rectangle = ones((1,2)) * self.bin_centers[-1]
+        white_extent = (self.high,
+                        self.ax_histo.axis()[1],
+                        self.ax_histo.axis()[2],
+                        self.ax_histo.axis()[3])
+        if len(self.ax_histo.images) > 2:
+            del self.ax_histo.images[-3:]
+        self.ax_histo.imshow(black_rectangle, aspect='auto',
+                             extent = black_extent)
+        self.ax_histo.imshow(white_rectangle, aspect='auto',
+                             extent = white_extent,
+                             vmin=self.bin_centers[0],
+                             vmax=self.bin_centers[-1])
+        self.ax_histo.imshow(colorbar, aspect = 'auto',
+                             extent = cbar_extent)
+        
     def reset(self):
         low, high = self.bin_centers[[0, -1]]
         self.slider_low.value = low

--- a/skloupe/viewers/core.py
+++ b/skloupe/viewers/core.py
@@ -95,10 +95,10 @@ class CollectionViewer(ImageViewer):
         h_new = h_old + 0.5
         self.fig.set_figheight(h_new)
         self.ax.set_position([0, 1 - h_old/h_new, 1, h_old/h_new])
-        ax_slider = self.fig.add_axes([0.05, 0, 0.9, 0.5 / h_new])
+        ax_slider = self.fig.add_axes([0.1, 0, 0.8, 0.5 / h_new])
         idx_range = (0, self.num_images-1)
         self.slider = Slider(ax_slider, idx_range, on_slide=self.update_image,
-                             value=0, value_fmt=None)
+                             value=0, value_fmt='%i')
         self.connect_event('key_press_event', self.on_keypressed)
 
     def set_image(self, image):

--- a/skloupe/viewers/core.py
+++ b/skloupe/viewers/core.py
@@ -122,9 +122,18 @@ class CollectionViewer(ImageViewer):
     Subclasses and plugins will likely extend the `update_image` method to add
     custom overlays or filter the displayed image.
 
+    Parameters
+    ----------
+    image_collection : list of images
+        List of images to be displayed.
+    update : {'on_slide' | 'on_release'}
+        Control whether image is updated on slide or release of the image
+        slider. Using 'on_release' will give smoother behavior when displaying
+        large images or when writing a plugin/subclass that requires heavy
+        computation.
     """
 
-    def __init__(self, image_collection, **kwargs):
+    def __init__(self, image_collection, update='on_slide', **kwargs):
         self.image_collection = image_collection
         self.index = 0
         self.num_images = len(self.image_collection)
@@ -138,8 +147,11 @@ class CollectionViewer(ImageViewer):
         self.ax.set_position([0, 1 - h_old/h_new, 1, h_old/h_new])
         ax_slider = self.fig.add_axes([0.1, 0, 0.8, 0.5 / h_new])
         idx_range = (0, self.num_images-1)
-        self.slider = Slider(ax_slider, idx_range, on_slide=self.update_index,
-                             value=0, value_fmt='%i')
+
+        slider_kws = dict(value=0, value_fmt='%i')
+        slider_kws[update] = self.update_index
+        self.slider = Slider(ax_slider, idx_range, **slider_kws)
+
         self.connect_event('key_press_event', self.on_keypressed)
 
     def update_index(self, index):

--- a/skloupe/viewers/core.py
+++ b/skloupe/viewers/core.py
@@ -16,6 +16,14 @@ class ImageViewer(object):
     This window is a simple container object that holds a Matplotlib axes
     for showing images. This doesn't subclass the Matplotlib axes (or figure)
     because there be dragons.
+
+    Attributes
+    ----------
+    image : array
+        Image being viewed.
+    climits : tuple
+        Intensity range (minimum, maximum) of *displayed* image. Intensity
+        values above and below limits are clipped, but remain in image array.
     """
 
     def __init__(self, image, **kwargs):
@@ -47,6 +55,15 @@ class ImageViewer(object):
     def image(self, image):
         self._image = image
         self.ax.images[0].set_array(image)
+
+    @property
+    def climits(self):
+        return self._imgplot.get_clim()
+
+    @climits.setter
+    def climits(self, limits):
+        cmin, cmax = limits
+        self._imgplot.set_clim(vmin=cmin, vmax=cmax)
 
     def connect_event(self, event, callback):
         cid = self.canvas.mpl_connect(event, callback)

--- a/skloupe/widgets/slider.py
+++ b/skloupe/widgets/slider.py
@@ -68,7 +68,7 @@ class Slider(base.MPLWidgetCompatibility, mwidgets.Slider):
 
         self.line_low, = ax.plot(x_low, [y0, y0], color='0.5', lw=2)
         self.line_high, = ax.plot(x_high, [y0, y0], color='0.7', lw=2)
-        self.val_handle, = ax.plot(value, y0, 'o',
+        self.val_handle, = ax.plot(value, y0, 'o', clip_on=False,
                                    mec='0.4', mfc='0.6', markersize=8)
 
         ax.set_xlim(value_range)


### PR DESCRIPTION
So I think it's ok like that (I tried to chase extra spaces and unwanted linefeeds).

I think that closing the image window should also close the plugin (but not the opposite), would it be enough to re-implement `on_close` ?. 
Also, I think the plugin window should not have the toolbar, but couldn't find a way to remove it, other than subclassing FIgureCanvas, and if I understand correctly, you don't want that, because you don't want to meddle in the affairs of dragons ...
